### PR TITLE
✨ Accumulate small terminal changes below threshold

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,8 @@ A comprehensive implementation guide is available in `docs/VibeTunnelTalk_Implem
 
 6. **Error Handling**: Implement reconnection logic for IPC socket, HTTP polling, and WebSocket connections
 
+7. **Debug Logs**: OpenAI updates and debug logs are written to `~/Library/Logs/VibeTunnelTalk/`. The most recent log file is named with a timestamp like `openai_updates_YYYYMMDD_HHMMSS.txt`
+
 ## Reference Implementation
 
 **OpenAI WebSocket Reference**: When troubleshooting WebSocket communication with OpenAI's Realtime API, refer to the reference implementation at `~/Developer/swift-realtime-openai`. This codebase provides:

--- a/VibeTunnelTalk/Managers/SmartTerminalProcessor+DebugLogging.swift
+++ b/VibeTunnelTalk/Managers/SmartTerminalProcessor+DebugLogging.swift
@@ -61,14 +61,19 @@ extension SmartTerminalProcessor {
         // Get buffer processing stats
         let bufferStats = getBufferProcessingStats()
 
+        // Check if this is a combined update
+        let isCombined = content.contains("---")
+        let updateType = isCombined ? "COMBINED UPDATE" : "Update"
+
         let entry = """
 
-        [\(timestamp)] - Update #\(totalUpdatesSent)
+        [\(timestamp)] - \(updateType) #\(totalUpdatesSent)
         ----------------------------------------
         Snapshots processed: \(totalSnapshotsProcessed)
         Data reduction: \(String(format: "%.1f%%", dataReductionRatio * 100))
         Characters sent: \(content.count)
         Buffer stats: \(bufferStats)
+        Accumulated pending: \(accumulatedChangeCount) chars
         ----------------------------------------
         CONTENT SENT TO OPENAI:
         \(content)
@@ -100,6 +105,11 @@ extension SmartTerminalProcessor {
                 }
             }
             stats.append("non_empty_cells=\(nonEmptyCells)")
+
+            // Add accumulation stats
+            if !accumulatedChanges.isEmpty {
+                stats.append("accumulated_updates=\(accumulatedChanges.count)")
+            }
         } else {
             stats.append("buffer=none")
         }

--- a/VibeTunnelTalk/Managers/SmartTerminalProcessor+DebugLogging.swift
+++ b/VibeTunnelTalk/Managers/SmartTerminalProcessor+DebugLogging.swift
@@ -107,8 +107,8 @@ extension SmartTerminalProcessor {
             stats.append("non_empty_cells=\(nonEmptyCells)")
 
             // Add accumulation stats
-            if !accumulatedChanges.isEmpty {
-                stats.append("accumulated_updates=\(accumulatedChanges.count)")
+            if !accumulatedDelta.isEmpty {
+                stats.append("accumulated_delta_size=\(accumulatedDelta.count)")
             }
         } else {
             stats.append("buffer=none")


### PR DESCRIPTION
## Summary
- Implements accumulation mechanism for small terminal changes that fall below the `minChangeThreshold`
- Prevents loss of incremental updates while maintaining efficient API usage
- Adds time-based flush mechanism to prevent stale accumulation

## Problem Solved
Previously, terminal changes below the threshold (default: 5 characters) were dropped and never sent to OpenAI, causing gaps in the narration experience when multiple small changes occurred sequentially.

## Solution
Small changes are now accumulated in a buffer and sent to OpenAI when:
- Combined accumulated changes exceed the threshold
- A large change occurs (accumulated changes are flushed with it)
- 5 seconds have elapsed since last accumulation (timeout flush)
- The processing session ends (cleanup flush)

## Implementation Details
- Added `accumulatedChanges` array to track pending small updates
- Added `accumulatedChangeCount` to track total accumulated characters
- Added `maxAccumulationInterval` (5 seconds) for time-based flushing
- Enhanced debug logging to distinguish combined updates from regular ones
- Ensures `stopProcessing()` flushes any remaining accumulated changes

## Testing
The implementation has been built and verified with xcodebuild. The accumulation logic:
1. Preserves all terminal output (no data loss)
2. Maintains efficient API usage through batching
3. Provides timely updates through the timeout mechanism
4. Properly cleans up on session end

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)